### PR TITLE
🔨 BREAKING CHANGE: Actualización mayor de Spring Boot y Spring Cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM eclipse-temurin:21-jdk-alpine
+FROM eclipse-temurin:21-jre-alpine
+
+# Instalar curl en la imagen
+RUN apk update && apk add curl
+
+# Copiar el archivo JAR
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+
+# Ejecutar la aplicación
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,10 +1,14 @@
-FROM maven:3.9.8-eclipse-temurin-21-alpine AS build
+FROM maven:3-eclipse-temurin-21-alpine AS build
 ENV HOME=/usr/app
 RUN mkdir -p $HOME
 WORKDIR $HOME
 ADD . $HOME
 RUN --mount=type=cache,target=/root/.m2 mvn -f $HOME/pom.xml clean package
 
-FROM eclipse-temurin:21-jdk-alpine
+FROM eclipse-temurin:21-jre-alpine
+
+# Instalar curl en la imagen final
+RUN apk update && apk add curl
+
 COPY --from=build /usr/app/target/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.1</version>
+		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sauce.agua.eureka</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2023.0.3</spring-cloud.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,5 +1,5 @@
 app:
-  port: 8761
+  port: ${APP_PORT:8761}
   logging: debug
 
 server:
@@ -24,4 +24,12 @@ logging:
     web: ${app.logging}
     org:
       springframework.cloud.config: ${app.logging}
-      
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
- feat(docker): cambiar de JDK a JRE para optimizar tamaño de imagen
- feat(docker): agregar soporte para curl en imágenes Docker
- feat(deps): actualizar Spring Boot de 3.3.1 a 3.4.1
- feat(deps): actualizar Spring Cloud a 2024.0.0
- feat(config): hacer configurable el puerto via APP_PORT
- feat(monitoring): agregar endpoints de actuator
- chore(docker): optimizar cache de Maven en build local
- docs(docker): mejorar documentación en Dockerfiles

# Cambios Técnicos
- Dockerfile: eclipse-temurin:21-jdk-alpine → eclipse-temurin:21-jre-alpine
- Dockerfile.local: maven:3.9.8 → maven:3
- pom.xml: actualización de versiones core
- bootstrap.yml: configuración de variables de entorno y monitoring

# Testing
- [x] Build de imagen Docker exitoso
- [x] Pruebas de conectividad con nuevo JRE
- [x] Validación de endpoints de actuator
- [x] Verificación de puerto configurable
- [x] Compatibilidad con nuevas versiones de Spring

Closes #4