### PR TITLE
📦 Mejoras en la gestión de dependencias del servidor Eureka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.1</version>
+		<version>3.4.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sauce.agua.eureka</groupId>
@@ -37,21 +37,46 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-bootstrap</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>9.0.0.CR1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>


### PR DESCRIPTION
- chore(deps): actualizar Spring Boot de 3.4.1 a 3.4.2
- feat(validation): agregar Hibernate Validator 9.0.0.CR1
- fix(deps): eliminar commons-logging redundante
- refactor(deps): reorganizar y optimizar dependencias de Spring Cloud
- perf(build): reducir tamaño del JAR mediante exclusiones

# Cambios Técnicos
- Exclusiones de commons-logging en:
  * spring-cloud-starter-bootstrap
  * spring-cloud-starter-netflix-eureka-server
  * spring-cloud-starter
- Reordenamiento de dependencias en pom.xml
- Actualización de versiones core
- Implementación de validaciones mejoradas

# Testing
- [ ] Build completo del proyecto
- [ ] Servidor Eureka operativo
- [ ] Registro de servicios
- [ ] Sistema de logs
- [ ] Validaciones de Hibernate

Closes #9