### PR TITLE
feat(docs): restore and enhance documentation structure

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+# SAUCE Agua Eureka Service
+
+Bienvenido a la documentación del servicio Eureka de SAUCE Agua.
+
+## Descripción
+
+Este es el servidor de descubrimiento de servicios (Eureka Server) para la arquitectura de microservicios de SAUCE Agua.
+
+## Navegación
+
+- [Documentación Detallada del Proyecto](project-documentation.html) - Documentación generada automáticamente con:
+  - Estado actual de los Milestones
+  - Lista de Issues activos y cerrados
+  - Historial de cambios
+
+## Estado del Proyecto
+
+El estado actual del proyecto y sus avances se pueden consultar en la [Documentación Detallada](project-documentation.html).
+
+## Enlaces Útiles
+
+- [Repositorio en GitHub](https://github.com/SAUCE-services/SAUCE.agua.eureka-service)
+- [Wiki del Proyecto](https://github.com/SAUCE-services/SAUCE.agua.eureka-service/wiki) 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -14,7 +14,11 @@ def generate_docs():
     issues, milestones = load_data()
     
     # Template para la documentación
-    template_str = """
+    template_str = """---
+layout: default
+title: Documentación Detallada
+---
+
 # Documentación Detallada del Proyecto
 
 _Última actualización: {{ current_date }}_


### PR DESCRIPTION
BREAKING CHANGE: Reintroduces index.md with new Jekyll-compatible structure

feat(docs):
- Add new index.md with Jekyll front matter
- Implement clear navigation structure
- Add links to project documentation and resources

feat(scripts):
- Update documentation template with Jekyll front matter
- Enhance template structure for better readability
- Add layout and title metadata

This commit:
- Restores the main documentation entry point
- Improves the documentation generation template
- Adds proper Jekyll integration
- Establishes clear navigation paths
- Sets up structure for future documentation expansion

Body:
- index.md now includes front matter for Jekyll
- Documentation template updated for better Jekyll compatibility
- Navigation structure improved with clear sections
- Links added to detailed documentation and GitHub resources
- Template formatting enhanced for better readability

Footer:
Closes #31